### PR TITLE
update kea config

### DIFF
--- a/playbooks/roles/ff.kea_dhcp4_server/templates/kea-dhcp4.conf.j2
+++ b/playbooks/roles/ff.kea_dhcp4_server/templates/kea-dhcp4.conf.j2
@@ -26,11 +26,6 @@
 			"packet-queue-size": 16
 		},
 
-		"control-socket": {
-			"socket-type": "unix",
-			"socket-name": "/tmp/kea4-ctrl-socket"
-		},
-
 		// Addresses will be assigned with a lifetime of {{ dhcp_valid_leasetime }} seconds.
 		// The client is told to start renewing after {{ dhcp_renew_timer }} seconds. If the server
 		// does not respond within {{ dhcp_rebind_timer }} seconds of the lease being granted, client
@@ -51,11 +46,6 @@
 			{
 				"name": "kea-dhcp4",
 				"output_options": [{ "output": "syslog:dhcpd" }],
-				"severity": "WARN"
-			},
-			{
-				"name": "kea-dhcp4.packets",
-				"output_options": [{ "output": "/dev/null" }],
 				"severity": "WARN"
 			}
 		],


### PR DESCRIPTION
This fixes the

`Error during command processing: invalid path in `output`: invalid path specified: '/dev', supported path is '/var/log/kea' (/etc/kea/kea-dhcp4.conf:58:23)`

And:
`DHCP4_INIT_FAIL failed to initialize Kea server: configuration error using file '/etc/kea/kea-dhcp4.conf': 'socket-name' is invalid: invalid path specified: '/tmp', supported path is '/var/run/kea'`

Error stopping latest kea versions from starting.